### PR TITLE
Uses 127.0.0.1 instead of localhost

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -1,6 +1,6 @@
 sparta_dev:
   adapter: mysql2
-  host: localhost
+  host: 127.0.0.1
   username: root
   password:
   database: sparta
@@ -8,18 +8,17 @@ sparta_dev:
 
 sparta_prod:
   adapter: mysql2
-  host: localhost
+  host: 127.0.0.1
   username: root
   password:
   database: sparta
   encoding: utf8
-  
+
 # Add any databases whose data you want to visualize here.
 # Note: they should be limited to read-only access!
 
 sample_impala_db:
   adapter: impala
-  host: localhost
-  port: 21000  
+  host: 127.0.0.1
+  port: 21000
   username: avibryant
-  


### PR DESCRIPTION
I got some really cryptic errors leaving these as localhost on osx. 127.0.0.1 should work better for most people as a default
